### PR TITLE
fixed decoding of empty JSON arrays, e.g. "[]"

### DIFF
--- a/trunk/examples/tests.lua
+++ b/trunk/examples/tests.lua
@@ -142,7 +142,7 @@ function testJSON4Lua()
   r,e = json.decode_scanConstant(s,2)
   assert(r==nil and e==6)
   
-  -- Test decode_scanArray
+  -- Test decode_scanArray  
   s = "[1,2,3]"
   r,e = json.decode_scanArray(s,1)
   assert(compareData(r,{1,2,3}))
@@ -169,6 +169,14 @@ function testJSON4Lua()
     "lua_is_great":true } ]]
   r,e = json.decode(s)
   assert(compareData(r, {primes={2,3,5,7,9},user={name='craig',age=35,programs_lua=true},lua_is_great=true}))
+
+  -- Test decode of empty array and object
+  s = "[]"
+  r,e = json.decode(s)
+  assert(compareData(r,{}))
+  s = "{}"
+  r,e = json.decode(s)
+  assert(compareData(r,{}))  
   
   -- Tests that unicode chars are preserved with escapes
   -- Unicode conversion tests removed because unicode conversion doesn't intrinsically make sense in Lua -

--- a/trunk/examples/tests.lua
+++ b/trunk/examples/tests.lua
@@ -142,7 +142,7 @@ function testJSON4Lua()
   r,e = json.decode_scanConstant(s,2)
   assert(r==nil and e==6)
   
-  -- Test decode_scanArray  
+  -- Test decode_scanArray
   s = "[1,2,3]"
   r,e = json.decode_scanArray(s,1)
   assert(compareData(r,{1,2,3}))

--- a/trunk/json/json.lua
+++ b/trunk/json/json.lua
@@ -308,9 +308,10 @@ do
 		:link(tt_ignore)             :to " \t\r\n"
 	
 	-- a value, pretty similar to tt_object_value
-	init_token_table (tt_array_seperator) "array ({ or [ or ' or \" or number or boolean or null expected)"
+	init_token_table (tt_array_seperator) "array ({ or [ or ] or ' or \" or number or boolean or null expected)"
 		:link(tt_object_key)         :to "{" 
 		:link(tt_array_seperator)    :to "[" 
+		:link(true)                  :to "]"
 		:link(tt_singlequote_string) :to "'" 
 		:link(tt_doublequote_string) :to '"'  
 		:link(tt_comment_start)      :to "/" 
@@ -470,7 +471,11 @@ do
 			i = i or 1
 			-- loop until ...
 			while true do
-				o[i] = read_value(next_token(tt_array_seperator),tt_array_seperator)
+				local sep = next_token(tt_array_seperator)
+				if sep == true then  -- ... we found a terminator token
+					return o 
+				end
+				o[i] = read_value(sep, tt_array_seperator)
 				local t = next_token(tt_array_value)
 				if t == tt_comment_start then
 					t = read_comment(tt_array_value)


### PR DESCRIPTION
Empty arrays are currently not handled properly in the parser. I added a test and fix for json.lua.
Please have a look.

Thanks,
Philipp

Ps. json.decode("[]") results in the following error:

lua: ./json.lua:366: Unexpected character at Line 1 character 2: ] (93) when reading array ({ or [ or ' or " or number or boolean or null expected)
Context: 
[]
 ^
stack traceback:
    [C]: in function 'error'
    ./json.lua:366: in function 'next_token'
    ./json.lua:473: in function <./json.lua:468>
    (tail call): ?
    (tail call): ?
    ./json.lua:513: in function 'decode'
    tests.lua:175: in function 'testJSON4Lua'
    tests.lua:222: in main chunk
    [C]: ?
