### PR TITLE
Fix - Add quoting of carriage return and remove quoting of single quo…

### DIFF
--- a/json4lua/json/json.lua
+++ b/json4lua/json/json.lua
@@ -332,7 +332,7 @@ end
 function encodeString(s)
   s = string.gsub(s,'\\','\\\\')
   s = string.gsub(s,'"','\\"')
-  s = string.gsub(s,"'","\\'")
+  s = string.gsub(s,'\r','\\r')
   s = string.gsub(s,'\n','\\n')
   s = string.gsub(s,'\t','\\t')
   return s 


### PR DESCRIPTION
…tes/apostrophes

Single quotes are not supposed to be escaped in compliant JSON and carriage return's should be escaped